### PR TITLE
docs(ai-team): Record .slnx-only directive

### DIFF
--- a/.ai-team/decisions/inbox/copilot-directive-slnx-only.md
+++ b/.ai-team/decisions/inbox/copilot-directive-slnx-only.md
@@ -1,0 +1,13 @@
+### 2026-02-19: Use .slnx format exclusively—no .sln conversions
+
+**By:** mpaulosky (via Copilot)
+
+**What:** Team must use .slnx (new solution file format for .NET 10.0) in all processes. No conversions to legacy .sln format.
+
+**Why:** User preference—ensures consistency with .NET 10.0 standard and prevents tooling confusion.
+
+**Implementation:**
+- All build workflows target `IssueManager.slnx` (not any `.sln` equivalent)
+- Agents should never auto-generate or suggest `.sln` files
+- When agents see `.sln` in output, treat it as a tooling error to flag
+- Documentation and scripts reference `.slnx` exclusively

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0" />
     <!-- MongoDB -->
+    <PackageVersion Include="MongoDB.Bson" Version="3.5.2" />
     <PackageVersion Include="MongoDB.Entities" Version="25.0.0" />
     <PackageVersion Include="MongoDB.Driver" Version="3.5.2" />
     <!-- API Documentation -->

--- a/IssueManager.slnx
+++ b/IssueManager.slnx
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project Format="1.0" ToolsVersion="Current">
   <Configurations>
     <Configuration>

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -8,5 +8,6 @@
 	</PropertyGroup>
 	<ItemGroup>
 	  <PackageReference Include="FluentValidation" />
+	  <PackageReference Include="MongoDB.Bson" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Records team decision to use .slnx format exclusively with no conversions to legacy .sln format