### PR TITLE
test: increase test coverage for Status, Category, Comment validators

### DIFF
--- a/tests/Unit.Tests/Validators/CreateCategoryValidatorTests.cs
+++ b/tests/Unit.Tests/Validators/CreateCategoryValidatorTests.cs
@@ -1,0 +1,180 @@
+using FluentAssertions;
+using Shared.Validators;
+
+namespace Tests.Unit.Validators;
+
+/// <summary>
+/// Unit tests for <see cref="CreateCategoryValidator"/>.
+/// </summary>
+public class CreateCategoryValidatorTests
+{
+	private readonly CreateCategoryValidator _validator = new();
+
+	[Fact]
+	public void CreateCategoryValidator_ValidCommand_ReturnsNoErrors()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand
+		{
+			CategoryName = "Bug",
+			CategoryDescription = "Software bugs and issues"
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+		result.Errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void CreateCategoryValidator_ValidCommandWithoutDescription_ReturnsNoErrors()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand
+		{
+			CategoryName = "Feature"
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+		result.Errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void CreateCategoryValidator_EmptyCategoryName_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand { CategoryName = "" };
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().HaveCountGreaterOrEqualTo(1);
+		result.Errors.Should().Contain(e => e.PropertyName == "CategoryName" && e.ErrorMessage.Contains("required"));
+	}
+
+	[Fact]
+	public void CreateCategoryValidator_CategoryNameTooShort_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand { CategoryName = "A" };
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().HaveCount(1);
+		result.Errors[0].PropertyName.Should().Be("CategoryName");
+		result.Errors[0].ErrorMessage.Should().Contain("at least 2 characters");
+	}
+
+	[Fact]
+	public void CreateCategoryValidator_CategoryNameExactly2Characters_IsValid()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand { CategoryName = "UI" };
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Fact]
+	public void CreateCategoryValidator_CategoryNameExactly100Characters_IsValid()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand
+		{
+			CategoryName = new string('A', 100)
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Fact]
+	public void CreateCategoryValidator_CategoryNameTooLong_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand
+		{
+			CategoryName = new string('A', 101)
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().HaveCount(1);
+		result.Errors[0].PropertyName.Should().Be("CategoryName");
+		result.Errors[0].ErrorMessage.Should().Contain("cannot exceed 100 characters");
+	}
+
+	[Fact]
+	public void CreateCategoryValidator_DescriptionExactly500Characters_IsValid()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand
+		{
+			CategoryName = "Bug",
+			CategoryDescription = new string('X', 500)
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Fact]
+	public void CreateCategoryValidator_DescriptionTooLong_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand
+		{
+			CategoryName = "Bug",
+			CategoryDescription = new string('X', 501)
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().HaveCount(1);
+		result.Errors[0].PropertyName.Should().Be("CategoryDescription");
+		result.Errors[0].ErrorMessage.Should().Contain("cannot exceed 500 characters");
+	}
+
+	[Fact]
+	public void CreateCategoryValidator_NullDescription_IsValid()
+	{
+		// Arrange
+		var command = new CreateCategoryCommand
+		{
+			CategoryName = "Bug",
+			CategoryDescription = null
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+	}
+}

--- a/tests/Unit.Tests/Validators/CreateCommentValidatorTests.cs
+++ b/tests/Unit.Tests/Validators/CreateCommentValidatorTests.cs
@@ -1,0 +1,166 @@
+using FluentAssertions;
+using MongoDB.Bson;
+using Shared.Validators;
+
+namespace Tests.Unit.Validators;
+
+/// <summary>
+/// Unit tests for <see cref="CreateCommentValidator"/>.
+/// </summary>
+public class CreateCommentValidatorTests
+{
+	private readonly CreateCommentValidator _validator = new();
+
+	[Fact]
+	public void CreateCommentValidator_ValidCommand_ReturnsNoErrors()
+	{
+		// Arrange
+		var command = new CreateCommentCommand
+		{
+			Title = "Comment Title",
+			CommentText = "This is a valid comment",
+			IssueId = ObjectId.GenerateNewId().ToString()
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+		result.Errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void CreateCommentValidator_EmptyCommentText_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new CreateCommentCommand
+		{
+			Title = "Title",
+			CommentText = "",
+			IssueId = ObjectId.GenerateNewId().ToString()
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().HaveCountGreaterOrEqualTo(1);
+		result.Errors.Should().Contain(e => e.PropertyName == "CommentText" && e.ErrorMessage.Contains("required"));
+	}
+
+	[Fact]
+	public void CreateCommentValidator_CommentTextExactly1Character_IsValid()
+	{
+		// Arrange
+		var command = new CreateCommentCommand
+		{
+			Title = "Title",
+			CommentText = "A",
+			IssueId = ObjectId.GenerateNewId().ToString()
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Fact]
+	public void CreateCommentValidator_CommentTextExactly5000Characters_IsValid()
+	{
+		// Arrange
+		var command = new CreateCommentCommand
+		{
+			Title = "Title",
+			CommentText = new string('X', 5000),
+			IssueId = ObjectId.GenerateNewId().ToString()
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Fact]
+	public void CreateCommentValidator_CommentTextTooLong_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new CreateCommentCommand
+		{
+			Title = "Title",
+			CommentText = new string('X', 5001),
+			IssueId = ObjectId.GenerateNewId().ToString()
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().HaveCount(1);
+		result.Errors[0].PropertyName.Should().Be("CommentText");
+		result.Errors[0].ErrorMessage.Should().Contain("cannot exceed 5000 characters");
+	}
+
+	[Fact]
+	public void CreateCommentValidator_EmptyIssueId_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new CreateCommentCommand
+		{
+			Title = "Title",
+			CommentText = "Comment text",
+			IssueId = ""
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "IssueId" && e.ErrorMessage.Contains("required"));
+	}
+
+	[Fact]
+	public void CreateCommentValidator_InvalidIssueId_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new CreateCommentCommand
+		{
+			Title = "Title",
+			CommentText = "Comment text",
+			IssueId = "not-a-valid-objectid"
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "IssueId" && e.ErrorMessage.Contains("valid ObjectId"));
+	}
+
+	[Fact]
+	public void CreateCommentValidator_ValidObjectId_PassesValidation()
+	{
+		// Arrange
+		var validObjectId = ObjectId.GenerateNewId().ToString();
+		var command = new CreateCommentCommand
+		{
+			Title = "Title",
+			CommentText = "Comment text",
+			IssueId = validObjectId
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+	}
+}

--- a/tests/Unit.Tests/Validators/CreateStatusValidatorTests.cs
+++ b/tests/Unit.Tests/Validators/CreateStatusValidatorTests.cs
@@ -1,0 +1,180 @@
+using FluentAssertions;
+using Shared.Validators;
+
+namespace Tests.Unit.Validators;
+
+/// <summary>
+/// Unit tests for <see cref="CreateStatusValidator"/>.
+/// </summary>
+public class CreateStatusValidatorTests
+{
+	private readonly CreateStatusValidator _validator = new();
+
+	[Fact]
+	public void CreateStatusValidator_ValidCommand_ReturnsNoErrors()
+	{
+		// Arrange
+		var command = new CreateStatusCommand
+		{
+			StatusName = "Open",
+			StatusDescription = "Issue is open for work"
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+		result.Errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void CreateStatusValidator_ValidCommandWithoutDescription_ReturnsNoErrors()
+	{
+		// Arrange
+		var command = new CreateStatusCommand
+		{
+			StatusName = "Closed"
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+		result.Errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void CreateStatusValidator_EmptyStatusName_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new CreateStatusCommand { StatusName = "" };
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().HaveCountGreaterOrEqualTo(1);
+		result.Errors.Should().Contain(e => e.PropertyName == "StatusName" && e.ErrorMessage.Contains("required"));
+	}
+
+	[Fact]
+	public void CreateStatusValidator_StatusNameTooShort_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new CreateStatusCommand { StatusName = "A" };
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().HaveCount(1);
+		result.Errors[0].PropertyName.Should().Be("StatusName");
+		result.Errors[0].ErrorMessage.Should().Contain("at least 2 characters");
+	}
+
+	[Fact]
+	public void CreateStatusValidator_StatusNameExactly2Characters_IsValid()
+	{
+		// Arrange
+		var command = new CreateStatusCommand { StatusName = "OK" };
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Fact]
+	public void CreateStatusValidator_StatusNameExactly100Characters_IsValid()
+	{
+		// Arrange
+		var command = new CreateStatusCommand
+		{
+			StatusName = new string('A', 100)
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Fact]
+	public void CreateStatusValidator_StatusNameTooLong_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new CreateStatusCommand
+		{
+			StatusName = new string('A', 101)
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().HaveCount(1);
+		result.Errors[0].PropertyName.Should().Be("StatusName");
+		result.Errors[0].ErrorMessage.Should().Contain("cannot exceed 100 characters");
+	}
+
+	[Fact]
+	public void CreateStatusValidator_DescriptionExactly500Characters_IsValid()
+	{
+		// Arrange
+		var command = new CreateStatusCommand
+		{
+			StatusName = "Open",
+			StatusDescription = new string('X', 500)
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Fact]
+	public void CreateStatusValidator_DescriptionTooLong_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new CreateStatusCommand
+		{
+			StatusName = "Open",
+			StatusDescription = new string('X', 501)
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().HaveCount(1);
+		result.Errors[0].PropertyName.Should().Be("StatusDescription");
+		result.Errors[0].ErrorMessage.Should().Contain("cannot exceed 500 characters");
+	}
+
+	[Fact]
+	public void CreateStatusValidator_NullDescription_IsValid()
+	{
+		// Arrange
+		var command = new CreateStatusCommand
+		{
+			StatusName = "Open",
+			StatusDescription = null
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+	}
+}

--- a/tests/Unit.Tests/Validators/DeleteCategoryValidatorTests.cs
+++ b/tests/Unit.Tests/Validators/DeleteCategoryValidatorTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using MongoDB.Bson;
+using Shared.Validators;
+
+namespace Tests.Unit.Validators;
+
+/// <summary>
+/// Unit tests for <see cref="DeleteCategoryValidator"/>.
+/// </summary>
+public class DeleteCategoryValidatorTests
+{
+	private readonly DeleteCategoryValidator _validator = new();
+
+	[Fact]
+	public void DeleteCategoryValidator_ValidCommand_ReturnsNoErrors()
+	{
+		// Arrange
+		var command = new DeleteCategoryCommand
+		{
+			Id = ObjectId.GenerateNewId().ToString()
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+		result.Errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void DeleteCategoryValidator_EmptyId_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new DeleteCategoryCommand { Id = "" };
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Id" && e.ErrorMessage.Contains("required"));
+	}
+
+	[Fact]
+	public void DeleteCategoryValidator_NullId_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new DeleteCategoryCommand { Id = null! };
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Id" && e.ErrorMessage.Contains("required"));
+	}
+}

--- a/tests/Unit.Tests/Validators/DeleteCommentValidatorTests.cs
+++ b/tests/Unit.Tests/Validators/DeleteCommentValidatorTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using MongoDB.Bson;
+using Shared.Validators;
+
+namespace Tests.Unit.Validators;
+
+/// <summary>
+/// Unit tests for <see cref="DeleteCommentValidator"/>.
+/// </summary>
+public class DeleteCommentValidatorTests
+{
+	private readonly DeleteCommentValidator _validator = new();
+
+	[Fact]
+	public void DeleteCommentValidator_ValidCommand_ReturnsNoErrors()
+	{
+		// Arrange
+		var command = new DeleteCommentCommand
+		{
+			Id = ObjectId.GenerateNewId().ToString()
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+		result.Errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void DeleteCommentValidator_EmptyId_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new DeleteCommentCommand { Id = "" };
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Id" && e.ErrorMessage.Contains("required"));
+	}
+
+	[Fact]
+	public void DeleteCommentValidator_NullId_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new DeleteCommentCommand { Id = null! };
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Id" && e.ErrorMessage.Contains("required"));
+	}
+}

--- a/tests/Unit.Tests/Validators/DeleteStatusValidatorTests.cs
+++ b/tests/Unit.Tests/Validators/DeleteStatusValidatorTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using MongoDB.Bson;
+using Shared.Validators;
+
+namespace Tests.Unit.Validators;
+
+/// <summary>
+/// Unit tests for <see cref="DeleteStatusValidator"/>.
+/// </summary>
+public class DeleteStatusValidatorTests
+{
+	private readonly DeleteStatusValidator _validator = new();
+
+	[Fact]
+	public void DeleteStatusValidator_ValidCommand_ReturnsNoErrors()
+	{
+		// Arrange
+		var command = new DeleteStatusCommand
+		{
+			Id = ObjectId.GenerateNewId().ToString()
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+		result.Errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void DeleteStatusValidator_EmptyId_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new DeleteStatusCommand { Id = "" };
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Id" && e.ErrorMessage.Contains("required"));
+	}
+
+	[Fact]
+	public void DeleteStatusValidator_NullId_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new DeleteStatusCommand { Id = null! };
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Id" && e.ErrorMessage.Contains("required"));
+	}
+}

--- a/tests/Unit.Tests/Validators/UpdateCategoryValidatorTests.cs
+++ b/tests/Unit.Tests/Validators/UpdateCategoryValidatorTests.cs
@@ -1,0 +1,123 @@
+using FluentAssertions;
+using MongoDB.Bson;
+using Shared.Validators;
+
+namespace Tests.Unit.Validators;
+
+/// <summary>
+/// Unit tests for <see cref="UpdateCategoryValidator"/>.
+/// </summary>
+public class UpdateCategoryValidatorTests
+{
+	private readonly UpdateCategoryValidator _validator = new();
+
+	[Fact]
+	public void UpdateCategoryValidator_ValidCommand_ReturnsNoErrors()
+	{
+		// Arrange
+		var command = new UpdateCategoryCommand
+		{
+			Id = ObjectId.GenerateNewId().ToString(),
+			CategoryName = "Enhancement",
+			CategoryDescription = "Improvements to existing features"
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+		result.Errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void UpdateCategoryValidator_EmptyId_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new UpdateCategoryCommand
+		{
+			Id = "",
+			CategoryName = "Bug"
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Id" && e.ErrorMessage.Contains("required"));
+	}
+
+	[Fact]
+	public void UpdateCategoryValidator_EmptyCategoryName_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new UpdateCategoryCommand
+		{
+			Id = ObjectId.GenerateNewId().ToString(),
+			CategoryName = ""
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "CategoryName" && e.ErrorMessage.Contains("required"));
+	}
+
+	[Fact]
+	public void UpdateCategoryValidator_CategoryNameTooShort_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new UpdateCategoryCommand
+		{
+			Id = ObjectId.GenerateNewId().ToString(),
+			CategoryName = "A"
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "CategoryName" && e.ErrorMessage.Contains("at least 2 characters"));
+	}
+
+	[Fact]
+	public void UpdateCategoryValidator_CategoryNameTooLong_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new UpdateCategoryCommand
+		{
+			Id = ObjectId.GenerateNewId().ToString(),
+			CategoryName = new string('A', 101)
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "CategoryName" && e.ErrorMessage.Contains("cannot exceed 100 characters"));
+	}
+
+	[Fact]
+	public void UpdateCategoryValidator_DescriptionTooLong_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new UpdateCategoryCommand
+		{
+			Id = ObjectId.GenerateNewId().ToString(),
+			CategoryName = "Bug",
+			CategoryDescription = new string('X', 501)
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "CategoryDescription" && e.ErrorMessage.Contains("cannot exceed 500 characters"));
+	}
+}

--- a/tests/Unit.Tests/Validators/UpdateCommentValidatorTests.cs
+++ b/tests/Unit.Tests/Validators/UpdateCommentValidatorTests.cs
@@ -1,0 +1,89 @@
+using FluentAssertions;
+using MongoDB.Bson;
+using Shared.Validators;
+
+namespace Tests.Unit.Validators;
+
+/// <summary>
+/// Unit tests for <see cref="UpdateCommentValidator"/>.
+/// </summary>
+public class UpdateCommentValidatorTests
+{
+	private readonly UpdateCommentValidator _validator = new();
+
+	[Fact]
+	public void UpdateCommentValidator_ValidCommand_ReturnsNoErrors()
+	{
+		// Arrange
+		var command = new UpdateCommentCommand
+		{
+			Id = ObjectId.GenerateNewId().ToString(),
+			Title = "Updated Title",
+			CommentText = "Updated comment text"
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+		result.Errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void UpdateCommentValidator_EmptyId_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new UpdateCommentCommand
+		{
+			Id = "",
+			Title = "Title",
+			CommentText = "Comment text"
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Id" && e.ErrorMessage.Contains("required"));
+	}
+
+	[Fact]
+	public void UpdateCommentValidator_EmptyCommentText_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new UpdateCommentCommand
+		{
+			Id = ObjectId.GenerateNewId().ToString(),
+			Title = "Title",
+			CommentText = ""
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "CommentText" && e.ErrorMessage.Contains("required"));
+	}
+
+	[Fact]
+	public void UpdateCommentValidator_CommentTextTooLong_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new UpdateCommentCommand
+		{
+			Id = ObjectId.GenerateNewId().ToString(),
+			Title = "Title",
+			CommentText = new string('X', 5001)
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "CommentText" && e.ErrorMessage.Contains("cannot exceed 5000 characters"));
+	}
+}

--- a/tests/Unit.Tests/Validators/UpdateStatusValidatorTests.cs
+++ b/tests/Unit.Tests/Validators/UpdateStatusValidatorTests.cs
@@ -1,0 +1,123 @@
+using FluentAssertions;
+using MongoDB.Bson;
+using Shared.Validators;
+
+namespace Tests.Unit.Validators;
+
+/// <summary>
+/// Unit tests for <see cref="UpdateStatusValidator"/>.
+/// </summary>
+public class UpdateStatusValidatorTests
+{
+	private readonly UpdateStatusValidator _validator = new();
+
+	[Fact]
+	public void UpdateStatusValidator_ValidCommand_ReturnsNoErrors()
+	{
+		// Arrange
+		var command = new UpdateStatusCommand
+		{
+			Id = ObjectId.GenerateNewId().ToString(),
+			StatusName = "In Progress",
+			StatusDescription = "Currently being worked on"
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+		result.Errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void UpdateStatusValidator_EmptyId_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new UpdateStatusCommand
+		{
+			Id = "",
+			StatusName = "Open"
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "Id" && e.ErrorMessage.Contains("required"));
+	}
+
+	[Fact]
+	public void UpdateStatusValidator_EmptyStatusName_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new UpdateStatusCommand
+		{
+			Id = ObjectId.GenerateNewId().ToString(),
+			StatusName = ""
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "StatusName" && e.ErrorMessage.Contains("required"));
+	}
+
+	[Fact]
+	public void UpdateStatusValidator_StatusNameTooShort_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new UpdateStatusCommand
+		{
+			Id = ObjectId.GenerateNewId().ToString(),
+			StatusName = "A"
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "StatusName" && e.ErrorMessage.Contains("at least 2 characters"));
+	}
+
+	[Fact]
+	public void UpdateStatusValidator_StatusNameTooLong_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new UpdateStatusCommand
+		{
+			Id = ObjectId.GenerateNewId().ToString(),
+			StatusName = new string('A', 101)
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "StatusName" && e.ErrorMessage.Contains("cannot exceed 100 characters"));
+	}
+
+	[Fact]
+	public void UpdateStatusValidator_DescriptionTooLong_ReturnsValidationError()
+	{
+		// Arrange
+		var command = new UpdateStatusCommand
+		{
+			Id = ObjectId.GenerateNewId().ToString(),
+			StatusName = "Open",
+			StatusDescription = new string('X', 501)
+		};
+
+		// Act
+		var result = _validator.Validate(command);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().Contain(e => e.PropertyName == "StatusDescription" && e.ErrorMessage.Contains("cannot exceed 500 characters"));
+	}
+}


### PR DESCRIPTION
Closes #46

Adds comprehensive unit tests for the validators merged in PR #45.

## Changes
- Added 53 new validator tests across 9 test files
- Tests cover Create, Update, and Delete commands for Status, Category, and Comment entities
- Test count increased from 62 to 115 (+85% increase)

## Test Coverage
All validators now have comprehensive tests covering:
- ✅ Happy path scenarios
- ✅ Required field validation
- ✅ Length constraints (min/max)
- ✅ ObjectId format validation (for Comment.IssueId)
- ✅ Edge cases and boundary values

## Build & Test Results
- Build: ✅ 0 errors, 0 warnings
- Tests: ✅ 115/115 passing (Unit.Tests only)

## Progress Toward 90% Coverage Goal
This PR adds foundational validator tests. Additional handler and integration tests will be needed to reach the 90% target.