### PR TITLE
fix(tests): replace CancellationToken.None with TestContext.Current.CancellationToken in Api.Tests.Integration

### DIFF
--- a/tests/Api.Tests.Integration/Handlers/DeleteIssueHandlerIntegrationTests.cs
+++ b/tests/Api.Tests.Integration/Handlers/DeleteIssueHandlerIntegrationTests.cs
@@ -38,7 +38,7 @@ public class DeleteIssueHandlerIntegrationTests
 		var command = new DeleteIssueCommand { Id = created.Value.Id };
 
 		// Act
-		await _handler.Handle(command, CancellationToken.None);
+		await _handler.Handle(command, TestContext.Current.CancellationToken);
 
 		// Assert - Verify Archived is set in a database
 		var getResult = await _repository.GetByIdAsync(created.Value.Id, TestContext.Current.CancellationToken);
@@ -57,7 +57,7 @@ public class DeleteIssueHandlerIntegrationTests
 		var command = new DeleteIssueCommand { Id = created.Value.Id };
 
 		// Act - Archive the issue
-		await _handler.Handle(command, CancellationToken.None);
+		await _handler.Handle(command, TestContext.Current.CancellationToken);
 
 		// Assert - GetAll (paginated) should exclude archived issues
 		var result = await _repository.GetAllAsync(1, 100, cancellationToken: TestContext.Current.CancellationToken);
@@ -73,7 +73,7 @@ public class DeleteIssueHandlerIntegrationTests
 		var command = new DeleteIssueCommand { Id = nonExistentId };
 
 		// Act
-		var result = await _handler.Handle(command, CancellationToken.None);
+		var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Success.Should().BeFalse();
@@ -90,7 +90,7 @@ public class DeleteIssueHandlerIntegrationTests
 		var command = new DeleteIssueCommand { Id = created.Value.Id };
 
 		// Act - Soft delete
-		await _handler.Handle(command, CancellationToken.None);
+		await _handler.Handle(command, TestContext.Current.CancellationToken);
 
 		// Assert - Record should still exist (soft delete)
 		var dbIssue = await _repository.GetByIdAsync(created.Value.Id, TestContext.Current.CancellationToken);
@@ -111,7 +111,7 @@ public class DeleteIssueHandlerIntegrationTests
 		var command = new DeleteIssueCommand { Id = created.Value.Id };
 
 		// Act - Delete already archived issue (should be idempotent)
-		await _handler.Handle(command, CancellationToken.None);
+		await _handler.Handle(command, TestContext.Current.CancellationToken);
 
 		// Assert - Should still be archived
 		var dbIssueResult = await _repository.GetByIdAsync(created.Value.Id, TestContext.Current.CancellationToken);
@@ -133,7 +133,7 @@ public class DeleteIssueHandlerIntegrationTests
 		var command = new DeleteIssueCommand { Id = created1.Value.Id };
 
 		// Act
-		await _handler.Handle(command, CancellationToken.None);
+		await _handler.Handle(command, TestContext.Current.CancellationToken);
 
 		// Assert
 		var getResult1 = await _repository.GetByIdAsync(created1.Value.Id, TestContext.Current.CancellationToken);

--- a/tests/Api.Tests.Integration/Handlers/IssueRepositorySearchTests.cs
+++ b/tests/Api.Tests.Integration/Handlers/IssueRepositorySearchTests.cs
@@ -55,7 +55,7 @@ public class IssueRepositorySearchTests
 		var query = new ListIssuesQuery { Page = 1, PageSize = 20, SearchTerm = "bug" };
 
 		// Act
-		var result = await _handler.Handle(query, CancellationToken.None);
+		var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Items.Should().HaveCount(2);
@@ -78,7 +78,7 @@ public class IssueRepositorySearchTests
 		var query = new ListIssuesQuery { Page = 1, PageSize = 20, AuthorName = "Alice" };
 
 		// Act
-		var result = await _handler.Handle(query, CancellationToken.None);
+		var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Items.Should().HaveCount(2);
@@ -104,7 +104,7 @@ public class IssueRepositorySearchTests
 		var query = new ListIssuesQuery { Page = 1, PageSize = 20 };
 
 		// Act
-		var result = await _handler.Handle(query, CancellationToken.None);
+		var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Items.Should().HaveCount(2);
@@ -135,7 +135,7 @@ public class IssueRepositorySearchTests
 		};
 
 		// Act
-		var result = await _handler.Handle(query, CancellationToken.None);
+		var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Items.Should().HaveCount(2);
@@ -159,7 +159,7 @@ public class IssueRepositorySearchTests
 		var query = new ListIssuesQuery { Page = 1, PageSize = 20, SearchTerm = "BuG" };
 
 		// Act
-		var result = await _handler.Handle(query, CancellationToken.None);
+		var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Items.Should().HaveCount(3);
@@ -181,7 +181,7 @@ public class IssueRepositorySearchTests
 		var query = new ListIssuesQuery { Page = 1, PageSize = 20, SearchTerm = "bug" };
 
 		// Act
-		var result = await _handler.Handle(query, CancellationToken.None);
+		var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Items.Should().HaveCount(2);
@@ -201,7 +201,7 @@ public class IssueRepositorySearchTests
 		var query = new ListIssuesQuery { Page = 1, PageSize = 20, SearchTerm = "bug" };
 
 		// Act
-		var result = await _handler.Handle(query, CancellationToken.None);
+		var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Items.Should().BeEmpty();
@@ -221,7 +221,7 @@ public class IssueRepositorySearchTests
 		var query = new ListIssuesQuery { Page = 1, PageSize = 20, AuthorName = "Charlie" };
 
 		// Act
-		var result = await _handler.Handle(query, CancellationToken.None);
+		var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Items.Should().BeEmpty();
@@ -254,7 +254,7 @@ public class IssueRepositorySearchTests
 		};
 
 		// Act
-		var result = await _handler.Handle(query, CancellationToken.None);
+		var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Items.Should().HaveCount(10);

--- a/tests/Api.Tests.Integration/Handlers/ListIssuesHandlerIntegrationTests.cs
+++ b/tests/Api.Tests.Integration/Handlers/ListIssuesHandlerIntegrationTests.cs
@@ -41,7 +41,7 @@ public class ListIssuesHandlerIntegrationTests
 		var query = new ListIssuesQuery { Page = 1, PageSize = 20 };
 
 		// Act
-		var result = await _handler.Handle(query, CancellationToken.None);
+		var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Items.Should().HaveCount(20);
@@ -64,7 +64,7 @@ public class ListIssuesHandlerIntegrationTests
 		var query = new ListIssuesQuery { Page = 2, PageSize = 20 };
 
 		// Act
-		var result = await _handler.Handle(query, CancellationToken.None);
+		var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Items.Should().HaveCount(20);
@@ -93,7 +93,7 @@ public class ListIssuesHandlerIntegrationTests
 		var query = new ListIssuesQuery { Page = 1, PageSize = 20 };
 
 		// Act
-		var result = await _handler.Handle(query, CancellationToken.None);
+		var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Total.Should().Be(7); // 10 - 3 archived = 7
@@ -107,7 +107,7 @@ public class ListIssuesHandlerIntegrationTests
 		var query = new ListIssuesQuery { Page = 1, PageSize = 20 };
 
 		// Act
-		var result = await _handler.Handle(query, CancellationToken.None);
+		var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Items.Should().BeEmpty();
@@ -128,7 +128,7 @@ public class ListIssuesHandlerIntegrationTests
 		var query = new ListIssuesQuery { Page = 3, PageSize = 20 };
 
 		// Act
-		var result = await _handler.Handle(query, CancellationToken.None);
+		var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Items.Should().HaveCount(2); // 42 - 40 = 2 on the last page
@@ -152,7 +152,7 @@ public class ListIssuesHandlerIntegrationTests
 
 		// Act
 		var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-		var result = await _handler.Handle(query, CancellationToken.None);
+		var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
 		stopwatch.Stop();
 
 		// Assert
@@ -174,7 +174,7 @@ public class ListIssuesHandlerIntegrationTests
 		var query = new ListIssuesQuery { Page = 1, PageSize = 20 };
 
 		// Act - List while creating a new issue
-		var listTask = _handler.Handle(query, CancellationToken.None);
+		var listTask = _handler.Handle(query, TestContext.Current.CancellationToken);
 
 		var newIssue = CreateTestIssueDto("Concurrent Issue", "Created during list");
 		var createTask = _repository.CreateAsync(newIssue, TestContext.Current.CancellationToken);

--- a/tests/Api.Tests.Integration/Handlers/UpdateIssueHandlerIntegrationTests.cs
+++ b/tests/Api.Tests.Integration/Handlers/UpdateIssueHandlerIntegrationTests.cs
@@ -42,7 +42,7 @@ public class UpdateIssueHandlerIntegrationTests
 		};
 
 		// Act
-		var result = await _handler.Handle(command, CancellationToken.None);
+		var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Success.Should().BeTrue();
@@ -73,7 +73,7 @@ public class UpdateIssueHandlerIntegrationTests
 		};
 
 		// Act
-		await _handler.Handle(command, CancellationToken.None);
+		await _handler.Handle(command, TestContext.Current.CancellationToken);
 
 		// Assert - Both fields should be updated atomically
 		var dbIssueResult = await _repository.GetByIdAsync(created.Value!.Id, TestContext.Current.CancellationToken);
@@ -96,7 +96,7 @@ public class UpdateIssueHandlerIntegrationTests
 		};
 
 		// Act
-		var result = await _handler.Handle(command, CancellationToken.None);
+		var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Success.Should().BeFalse();
@@ -151,7 +151,7 @@ public class UpdateIssueHandlerIntegrationTests
 		};
 
 		// Act
-		var result = await _handler.Handle(command, CancellationToken.None);
+		var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
 
 		// Assert
 		result.Success.Should().BeFalse();


### PR DESCRIPTION
Fixes 27 failing integration tests across 4 handler test files.

xUnit v3 requires `TestContext.Current.CancellationToken` instead of `CancellationToken.None` for proper test lifecycle management.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>