### PR TITLE
feat: Add manual workflow_dispatch trigger to squad-ci.yml

### DIFF
--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -2,6 +2,12 @@ name: Squad CI
 # Calls the squad-test.yml workflow for build and test execution
 
 on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual run'
+        required: false
+        default: 'Manual CI verification'
   pull_request:
     branches: [dev, preview, main, insider]
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
## Summary
Enables manual CI workflow execution via GitHub Actions UI.

## Changes
- Added `workflow_dispatch` trigger to squad-ci.yml
- Optional `reason` input field for documenting manual runs

## How to Use
1. Go to Actions → Squad CI
2. Click "Run workflow"
3. Optionally enter a reason
4. Click "Run workflow" button

Closes #105