### PR TITLE
feat: add DeleteStatus archive handler and endpoint

### DIFF
--- a/src/Api/Data/Interfaces/IIssueRepository.cs
+++ b/src/Api/Data/Interfaces/IIssueRepository.cs
@@ -42,8 +42,10 @@ public interface IIssueRepository
 	/// <param name="pageSize">The number of items per page.</param>
 	/// <param name="searchTerm">Optional search term to filter by title or description.</param>
 	/// <param name="authorName">Optional author name to filter by.</param>
+	/// <param name="statusName">Optional status name to filter by.</param>
+	/// <param name="categoryName">Optional category name to filter by.</param>
 	/// <param name="cancellationToken">Cancellation token.</param>
-	Task<Result<(IReadOnlyList<IssueDto> Items, long Total)>> GetAllAsync(int page, int pageSize, string? searchTerm = null, string? authorName = null, CancellationToken cancellationToken = default);
+	Task<Result<(IReadOnlyList<IssueDto> Items, long Total)>> GetAllAsync(int page, int pageSize, string? searchTerm = null, string? authorName = null, string? statusName = null, string? categoryName = null, CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Updates an existing issue in the database.

--- a/src/Api/Data/IssueRepository.cs
+++ b/src/Api/Data/IssueRepository.cs
@@ -72,6 +72,8 @@ public class IssueRepository : IIssueRepository
 			int pageSize,
 			string? searchTerm = null,
 			string? authorName = null,
+			string? statusName = null,
+			string? categoryName = null,
 			CancellationToken cancellationToken = default)
 	{
 		var filterBuilder = Builders<Issue>.Filter;
@@ -92,6 +94,16 @@ public class IssueRepository : IIssueRepository
 		if (!string.IsNullOrWhiteSpace(authorName))
 		{
 			filters.Add(filterBuilder.Regex(x => x.Author.Name, new BsonRegularExpression(authorName, "i")));
+		}
+
+		if (!string.IsNullOrWhiteSpace(statusName))
+		{
+			filters.Add(filterBuilder.Regex(x => x.Status.StatusName, new BsonRegularExpression(statusName, "i")));
+		}
+
+		if (!string.IsNullOrWhiteSpace(categoryName))
+		{
+			filters.Add(filterBuilder.Regex(x => x.Category.CategoryName, new BsonRegularExpression(categoryName, "i")));
 		}
 
 		var filter = filterBuilder.And(filters);

--- a/src/Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Api/Extensions/ServiceCollectionExtensions.cs
@@ -73,6 +73,7 @@ public static class ServiceCollectionExtensions
 		services.AddScoped<GetStatusHandler>();
 		services.AddScoped<ListStatusesHandler>();
 		services.AddScoped<UpdateStatusHandler>();
+		services.AddScoped<DeleteStatusHandler>();
 		services.AddScoped<CreateCategoryHandler>();
 		services.AddScoped<GetCategoryHandler>();
 		services.AddScoped<ListCategoriesHandler>();

--- a/src/Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Api/Extensions/ServiceCollectionExtensions.cs
@@ -77,6 +77,7 @@ public static class ServiceCollectionExtensions
 		services.AddScoped<GetCategoryHandler>();
 		services.AddScoped<ListCategoriesHandler>();
 		services.AddScoped<UpdateCategoryHandler>();
+		services.AddScoped<DeleteCategoryHandler>();
 		services.AddScoped<CreateCommentHandler>();
 		services.AddScoped<GetCommentHandler>();
 		services.AddScoped<ListCommentsHandler>();

--- a/src/Api/Handlers/Categories/CategoryEndpoints.cs
+++ b/src/Api/Handlers/Categories/CategoryEndpoints.cs
@@ -66,6 +66,20 @@ public static class CategoryEndpoints
 		.Produces(StatusCodes.Status404NotFound)
 		.RequireAuthorization();
 
+		group.MapDelete("{id}", async (string id, DeleteCategoryHandler handler) =>
+		{
+			if (!ObjectId.TryParse(id, out var objectId))
+				return Results.BadRequest("Invalid ID format");
+			var command = new DeleteCategoryCommand { Id = objectId };
+			var result = await handler.Handle(command);
+			return result.Success ? Results.NoContent() : Results.NotFound();
+		})
+		.WithName("DeleteCategory")
+		.WithSummary("Delete (archive) a category")
+		.Produces(StatusCodes.Status204NoContent)
+		.Produces(StatusCodes.Status404NotFound)
+		.RequireAuthorization();
+
 		return app;
 	}
 }

--- a/src/Api/Handlers/Issues/IssueEndpoints.cs
+++ b/src/Api/Handlers/Issues/IssueEndpoints.cs
@@ -21,14 +21,16 @@ public static class IssueEndpoints
 		var group = app.MapGroup("/api/v1/issues").WithTags("Issues");
 
 		// List Issues (paginated)
-		group.MapGet("", async (int? page, int? pageSize, string? searchTerm, string? authorName, ListIssuesHandler handler) =>
+		group.MapGet("", async (int? page, int? pageSize, string? searchTerm, string? authorName, string? statusName, string? categoryName, ListIssuesHandler handler) =>
 		{
 			var query = new ListIssuesQuery
 			{
 				Page = page ?? 1,
 				PageSize = pageSize ?? 20,
 				SearchTerm = searchTerm,
-				AuthorName = authorName
+				AuthorName = authorName,
+				StatusName = statusName,
+				CategoryName = categoryName
 			};
 			var result = await handler.Handle(query);
 			return Results.Ok(result);

--- a/src/Api/Handlers/Issues/ListIssuesHandler.cs
+++ b/src/Api/Handlers/Issues/ListIssuesHandler.cs
@@ -35,7 +35,7 @@ public class ListIssuesHandler
 		if (!validationResult.IsValid)
 			throw new ValidationException(validationResult.Errors);
 
-		var result = await _repository.GetAllAsync(query.Page, query.PageSize, query.SearchTerm, query.AuthorName, cancellationToken);
+		var result = await _repository.GetAllAsync(query.Page, query.PageSize, query.SearchTerm, query.AuthorName, query.StatusName, query.CategoryName, cancellationToken);
 		var (items, total) = result.Value;
 
 		return new PaginatedResponse<IssueDto>(items, total, query.Page, query.PageSize);

--- a/src/Api/Handlers/Statuses/DeleteStatusHandler.cs
+++ b/src/Api/Handlers/Statuses/DeleteStatusHandler.cs
@@ -1,11 +1,11 @@
-// =======================================================
+// =============================================
 // Copyright (c) 2026. All rights reserved.
 // File Name :     DeleteStatusHandler.cs
 // Company :       mpaulosky
 // Author :        Matthew Paulosky
 // Solution Name : IssueManager
 // Project Name :  Api
-// =======================================================
+// =============================================
 
 namespace Api.Handlers.Statuses;
 

--- a/src/Api/Handlers/Statuses/StatusEndpoints.cs
+++ b/src/Api/Handlers/Statuses/StatusEndpoints.cs
@@ -70,6 +70,20 @@ public static class StatusEndpoints
 		.Produces(StatusCodes.Status404NotFound)
 		.RequireAuthorization();
 
+		group.MapDelete("{id}", async (string id, DeleteStatusHandler handler) =>
+		{
+			if (!ObjectId.TryParse(id, out var objectId))
+				return Results.BadRequest("Invalid ID format");
+			var command = new DeleteStatusCommand { Id = objectId };
+			var result = await handler.Handle(command);
+			return result.Success ? Results.NoContent() : Results.NotFound();
+		})
+		.WithName("DeleteStatus")
+		.WithSummary("Delete (archive) a status")
+		.Produces(StatusCodes.Status204NoContent)
+		.Produces(StatusCodes.Status404NotFound)
+		.RequireAuthorization();
+
 		return app;
 	}
 }

--- a/src/Shared/Contracts/ListIssuesQuery.cs
+++ b/src/Shared/Contracts/ListIssuesQuery.cs
@@ -32,4 +32,14 @@ public record ListIssuesQuery
 	/// Gets or sets the author name for filtering by author.
 	/// </summary>
 	public string? AuthorName { get; init; }
+
+	/// <summary>
+	/// Gets or sets the status name for filtering by status.
+	/// </summary>
+	public string? StatusName { get; init; }
+
+	/// <summary>
+	/// Gets or sets the category name for filtering by category.
+	/// </summary>
+	public string? CategoryName { get; init; }
 }

--- a/src/Web/Components/Features/Issues/IssueApiClient.cs
+++ b/src/Web/Components/Features/Issues/IssueApiClient.cs
@@ -17,8 +17,10 @@ public interface IIssueApiClient
 	/// <param name="pageSize">The number of items per page.</param>
 	/// <param name="searchTerm">Optional search term to filter by title or description.</param>
 	/// <param name="authorName">Optional author name to filter by.</param>
+	/// <param name="statusName">Optional status name to filter by.</param>
+	/// <param name="categoryName">Optional category name to filter by.</param>
 	/// <param name="cancellationToken">Cancellation token.</param>
-	Task<PaginatedResponse<IssueDto>> GetAllAsync(int page = 1, int pageSize = 20, string? searchTerm = null, string? authorName = null, CancellationToken cancellationToken = default);
+	Task<PaginatedResponse<IssueDto>> GetAllAsync(int page = 1, int pageSize = 20, string? searchTerm = null, string? authorName = null, string? statusName = null, string? categoryName = null, CancellationToken cancellationToken = default);
 
 	/// <summary>Gets an issue by its identifier.</summary>
 	Task<IssueDto?> GetByIdAsync(string id, CancellationToken cancellationToken = default);
@@ -45,7 +47,7 @@ public class IssueApiClient : IIssueApiClient
 	public IssueApiClient(HttpClient httpClient) => _httpClient = httpClient;
 
 	/// <inheritdoc/>
-	public async Task<PaginatedResponse<IssueDto>> GetAllAsync(int page = 1, int pageSize = 20, string? searchTerm = null, string? authorName = null, CancellationToken cancellationToken = default)
+	public async Task<PaginatedResponse<IssueDto>> GetAllAsync(int page = 1, int pageSize = 20, string? searchTerm = null, string? authorName = null, string? statusName = null, string? categoryName = null, CancellationToken cancellationToken = default)
 	{
 		try
 		{
@@ -57,6 +59,14 @@ public class IssueApiClient : IIssueApiClient
 			if (!string.IsNullOrWhiteSpace(authorName))
 			{
 				url += $"&authorName={Uri.EscapeDataString(authorName)}";
+			}
+			if (!string.IsNullOrWhiteSpace(statusName))
+			{
+				url += $"&statusName={Uri.EscapeDataString(statusName)}";
+			}
+			if (!string.IsNullOrWhiteSpace(categoryName))
+			{
+				url += $"&categoryName={Uri.EscapeDataString(categoryName)}";
 			}
 
 			var result = await _httpClient.GetFromJsonAsync<PaginatedResponse<IssueDto>>(url, cancellationToken).ConfigureAwait(false);

--- a/src/Web/Components/Features/Issues/IssuesPage.razor
+++ b/src/Web/Components/Features/Issues/IssuesPage.razor
@@ -153,7 +153,7 @@
 		_currentPage = page;
 		try
 		{
-			var response = await IssueClient.GetAllAsync(page, 20);
+			var response = await IssueClient.GetAllAsync(page, 20, _searchTerm, null, _statusFilter, _categoryFilter);
 			_issues = response.Items;
 			_totalPages = response.TotalPages;
 		}

--- a/tests/Api.Tests.Unit/Endpoints/IssueEndpointsTests.cs
+++ b/tests/Api.Tests.Unit/Endpoints/IssueEndpointsTests.cs
@@ -39,7 +39,7 @@ public class IssueEndpointsTests : IDisposable
 		// Arrange
 		IReadOnlyList<IssueDto> items = [];
 		_factory.IssueRepository
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Result<(IReadOnlyList<IssueDto> Items, long Total)>.Ok((items, 0L)));
 
 		// Act

--- a/tests/Api.Tests.Unit/Handlers/Issues/ListIssuesHandlerTests.cs
+++ b/tests/Api.Tests.Unit/Handlers/Issues/ListIssuesHandlerTests.cs
@@ -33,7 +33,7 @@ public class ListIssuesHandlerTests
 		var query = new ListIssuesQuery { Page = 1, PageSize = 20 };
 
 		var issues = GenerateIssueDtos(20);
-		_repository.GetAllAsync(1, 20, null, null, Arg.Any<CancellationToken>())
+		_repository.GetAllAsync(1, 20, null, null, null, null, Arg.Any<CancellationToken>())
 		.Returns(((IReadOnlyList<IssueDto>)issues, 42L));
 
 		// Act
@@ -54,7 +54,7 @@ public class ListIssuesHandlerTests
 		var query = new ListIssuesQuery { Page = 2, PageSize = 10 };
 
 		var issues = GenerateIssueDtos(10);
-		_repository.GetAllAsync(2, 10, null, null, Arg.Any<CancellationToken>())
+		_repository.GetAllAsync(2, 10, null, null, null, null, Arg.Any<CancellationToken>())
 		.Returns(((IReadOnlyList<IssueDto>)issues, 42L));
 
 		// Act
@@ -75,7 +75,7 @@ public class ListIssuesHandlerTests
 		var query = new ListIssuesQuery { Page = 3, PageSize = 20 };
 
 		var issues = GenerateIssueDtos(2); // Last page has only 2 items
-		_repository.GetAllAsync(3, 20, null, null, Arg.Any<CancellationToken>())
+		_repository.GetAllAsync(3, 20, null, null, null, null, Arg.Any<CancellationToken>())
 		.Returns(((IReadOnlyList<IssueDto>)issues, 42L));
 
 		// Act
@@ -95,7 +95,7 @@ public class ListIssuesHandlerTests
 		// Arrange
 		var query = new ListIssuesQuery { Page = 1, PageSize = 20 };
 
-		_repository.GetAllAsync(1, 20, null, null, Arg.Any<CancellationToken>())
+		_repository.GetAllAsync(1, 20, null, null, null, null, Arg.Any<CancellationToken>())
 		.Returns(((IReadOnlyList<IssueDto>)new List<IssueDto>(), 0L));
 
 		// Act
@@ -115,7 +115,7 @@ public class ListIssuesHandlerTests
 		// Arrange
 		var query = new ListIssuesQuery { Page = 10, PageSize = 20 };
 
-		_repository.GetAllAsync(10, 20, null, null, Arg.Any<CancellationToken>())
+		_repository.GetAllAsync(10, 20, null, null, null, null, Arg.Any<CancellationToken>())
 		.Returns(((IReadOnlyList<IssueDto>)new List<IssueDto>(), 42L));
 
 		// Act
@@ -176,14 +176,14 @@ public class ListIssuesHandlerTests
 		var query = new ListIssuesQuery { Page = 1, PageSize = 20 };
 
 		var issues = GenerateIssueDtos(10);
-		_repository.GetAllAsync(1, 20, null, null, Arg.Any<CancellationToken>())
+		_repository.GetAllAsync(1, 20, null, null, null, null, Arg.Any<CancellationToken>())
 		.Returns(((IReadOnlyList<IssueDto>)issues, 10L));
 
 		// Act
 		var result = await _handler.Handle(query, CancellationToken.None);
 
 		// Assert
-		await _repository.Received(1).GetAllAsync(1, 20, null, null, Arg.Any<CancellationToken>());
+		await _repository.Received(1).GetAllAsync(1, 20, null, null, null, null, Arg.Any<CancellationToken>());
 		result.Items.Should().HaveCount(10);
 	}
 
@@ -201,7 +201,7 @@ public class ListIssuesHandlerTests
 			new(ObjectId.GenerateNewId(), "Issue 1", "Desc", DateTime.UtcNow.AddDays(-3), null, UserDto.Empty, CategoryDto.Empty, StatusDto.Empty, false, UserDto.Empty, false, false),
 		};
 
-		_repository.GetAllAsync(1, 3, null, null, Arg.Any<CancellationToken>())
+		_repository.GetAllAsync(1, 3, null, null, null, null, Arg.Any<CancellationToken>())
 		.Returns(((IReadOnlyList<IssueDto>)orderedIssues, 3L));
 
 		// Act

--- a/tests/Web.Tests.Bunit/Components/Features/Admin/AdminPageTests.cs
+++ b/tests/Web.Tests.Bunit/Components/Features/Admin/AdminPageTests.cs
@@ -31,7 +31,7 @@ public class AdminPageTests : IDisposable
 
 		_mockIssueClient = Substitute.For<IIssueApiClient>();
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(PaginatedResponse<IssueDto>.Empty));
 		_ctx.Services.AddSingleton(_mockIssueClient);
 	}
@@ -81,7 +81,7 @@ public class AdminPageTests : IDisposable
 
 		// Assert
 		_mockIssueClient.Received(1)
-			.GetAllAsync(Arg.Any<int>(), 100, Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+			.GetAllAsync(Arg.Any<int>(), 100, Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
 	}
 
 	[Fact]
@@ -102,7 +102,7 @@ public class AdminPageTests : IDisposable
 		// Arrange
 		var issue = MakePendingIssue("My Pending Bug");
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 
 		// Act
@@ -118,7 +118,7 @@ public class AdminPageTests : IDisposable
 		// Arrange
 		var issue = MakePendingIssue("Info Issue");
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 
 		// Act
@@ -137,7 +137,7 @@ public class AdminPageTests : IDisposable
 		// Arrange
 		var approvedIssue = MakePendingIssue("Approved Issue") with { ApprovedForRelease = true };
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(approvedIssue)));
 
 		// Act
@@ -154,7 +154,7 @@ public class AdminPageTests : IDisposable
 		// Arrange
 		var rejectedIssue = MakePendingIssue("Rejected Issue") with { Rejected = true };
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(rejectedIssue)));
 
 		// Act
@@ -172,7 +172,7 @@ public class AdminPageTests : IDisposable
 		var issue1 = MakePendingIssue("Issue One");
 		var issue2 = MakePendingIssue("Issue Two");
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue1, issue2)));
 
 		// Act
@@ -194,7 +194,7 @@ public class AdminPageTests : IDisposable
 		var issue = MakePendingIssue("Issue To Approve");
 		var updatedIssue = issue with { ApprovedForRelease = true };
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 		_mockIssueClient
 			.UpdateAsync(issue.Id.ToString(), Arg.Any<UpdateIssueCommand>(), Arg.Any<CancellationToken>())
@@ -220,7 +220,7 @@ public class AdminPageTests : IDisposable
 		var issue = MakePendingIssue("Issue To Approve");
 		var updatedIssue = issue with { ApprovedForRelease = true };
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 		_mockIssueClient
 			.UpdateAsync(issue.Id.ToString(), Arg.Any<UpdateIssueCommand>(), Arg.Any<CancellationToken>())
@@ -241,7 +241,7 @@ public class AdminPageTests : IDisposable
 		// Arrange
 		var issue = MakePendingIssue("Issue That Stays");
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 		_mockIssueClient
 			.UpdateAsync(issue.Id.ToString(), Arg.Any<UpdateIssueCommand>(), Arg.Any<CancellationToken>())
@@ -265,7 +265,7 @@ public class AdminPageTests : IDisposable
 		var issue = MakePendingIssue("Issue To Reject");
 		var updatedIssue = issue with { Rejected = true };
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 		_mockIssueClient
 			.UpdateAsync(issue.Id.ToString(), Arg.Any<UpdateIssueCommand>(), Arg.Any<CancellationToken>())
@@ -291,7 +291,7 @@ public class AdminPageTests : IDisposable
 		var issue = MakePendingIssue("Issue To Reject");
 		var updatedIssue = issue with { Rejected = true };
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 		_mockIssueClient
 			.UpdateAsync(issue.Id.ToString(), Arg.Any<UpdateIssueCommand>(), Arg.Any<CancellationToken>())
@@ -312,7 +312,7 @@ public class AdminPageTests : IDisposable
 		// Arrange
 		var issue = MakePendingIssue("Rejection Fails");
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 		_mockIssueClient
 			.UpdateAsync(issue.Id.ToString(), Arg.Any<UpdateIssueCommand>(), Arg.Any<CancellationToken>())
@@ -335,7 +335,7 @@ public class AdminPageTests : IDisposable
 		// Arrange
 		var issue = MakePendingIssue("Title To Edit");
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 
 		var cut = _ctx.Render<AdminPage>();
@@ -353,7 +353,7 @@ public class AdminPageTests : IDisposable
 		// Arrange
 		var issue = MakePendingIssue("Dual Edit Issue");
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 
 		var cut = _ctx.Render<AdminPage>();
@@ -375,7 +375,7 @@ public class AdminPageTests : IDisposable
 		var issue = MakePendingIssue("Original Title");
 		var updatedIssue = issue with { Title = "Updated Title" };
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 		_mockIssueClient
 			.UpdateAsync(issue.Id.ToString(), Arg.Any<UpdateIssueCommand>(), Arg.Any<CancellationToken>())
@@ -403,7 +403,7 @@ public class AdminPageTests : IDisposable
 		var issue = MakePendingIssue("Title To Save");
 		var updatedIssue = issue with { Title = "Saved Title" };
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 		_mockIssueClient
 			.UpdateAsync(Arg.Any<string>(), Arg.Any<UpdateIssueCommand>(), Arg.Any<CancellationToken>())
@@ -426,7 +426,7 @@ public class AdminPageTests : IDisposable
 		// Arrange
 		var issue = MakePendingIssue("Title To Cancel");
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 
 		var cut = _ctx.Render<AdminPage>();
@@ -447,7 +447,7 @@ public class AdminPageTests : IDisposable
 		// Arrange
 		var issue = MakePendingIssue("Issue", "Description To Edit");
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 
 		var cut = _ctx.Render<AdminPage>();
@@ -465,7 +465,7 @@ public class AdminPageTests : IDisposable
 		// Arrange
 		var issue = MakePendingIssue("Clear Title On Desc Edit");
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 
 		var cut = _ctx.Render<AdminPage>();
@@ -487,7 +487,7 @@ public class AdminPageTests : IDisposable
 		var issue = MakePendingIssue("Issue", "Original Description");
 		var updatedIssue = issue with { Description = "Updated Description" };
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 		_mockIssueClient
 			.UpdateAsync(issue.Id.ToString(), Arg.Any<UpdateIssueCommand>(), Arg.Any<CancellationToken>())
@@ -515,7 +515,7 @@ public class AdminPageTests : IDisposable
 		var issue = MakePendingIssue("Issue", "Desc To Save");
 		var updatedIssue = issue with { Description = "Saved Description" };
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 		_mockIssueClient
 			.UpdateAsync(Arg.Any<string>(), Arg.Any<UpdateIssueCommand>(), Arg.Any<CancellationToken>())
@@ -538,7 +538,7 @@ public class AdminPageTests : IDisposable
 		// Arrange
 		var issue = MakePendingIssue("Issue", "Description To Cancel");
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 
 		var cut = _ctx.Render<AdminPage>();

--- a/tests/Web.Tests.Bunit/Components/Features/Issues/IssuesPageTests.cs
+++ b/tests/Web.Tests.Bunit/Components/Features/Issues/IssuesPageTests.cs
@@ -25,7 +25,7 @@ public class IssuesPageTests : ComponentTestBase
 	{
 		_mockIssueClient = Substitute.For<IIssueApiClient>();
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(PaginatedResponse<IssueDto>.Empty));
 		TestContext.Services.AddSingleton(_mockIssueClient);
 	}
@@ -111,7 +111,7 @@ public class IssuesPageTests : ComponentTestBase
 			1,
 			20);
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(response));
 
 		// Act
@@ -129,7 +129,7 @@ public class IssuesPageTests : ComponentTestBase
 
 		// Assert
 		_mockIssueClient.Received(1)
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
 	}
 
 	[Fact]
@@ -143,6 +143,6 @@ public class IssuesPageTests : ComponentTestBase
 
 		// Assert — once on init, once on clear
 		_ = _mockIssueClient.Received(2)
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
 	}
 }

--- a/tests/Web.Tests.Bunit/Components/Features/Profile/ProfilePageTests.cs
+++ b/tests/Web.Tests.Bunit/Components/Features/Profile/ProfilePageTests.cs
@@ -31,7 +31,7 @@ public class ProfilePageTests : IDisposable
 
 		_mockIssueClient = Substitute.For<IIssueApiClient>();
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(PaginatedResponse<IssueDto>.Empty));
 		_ctx.Services.AddSingleton(_mockIssueClient);
 	}
@@ -81,7 +81,7 @@ public class ProfilePageTests : IDisposable
 
 		// Assert
 		_mockIssueClient.Received(1)
-			.GetAllAsync(Arg.Any<int>(), 200, Arg.Any<string?>(), "testuser", Arg.Any<CancellationToken>());
+			.GetAllAsync(Arg.Any<int>(), 200, Arg.Any<string?>(), "testuser", Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
 	}
 
 	// ─── Issue Filtering ─────────────────────────────────────────────────────────
@@ -92,7 +92,7 @@ public class ProfilePageTests : IDisposable
 		// Arrange — approved: ApprovedForRelease=true, Rejected=false, Archived=false
 		var issue = MakeIssue("Approved Issue") with { ApprovedForRelease = true };
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 
 		// Act
@@ -109,7 +109,7 @@ public class ProfilePageTests : IDisposable
 		// Arrange — pending: ApprovedForRelease=false, Rejected=false, Archived=false (defaults)
 		var issue = MakeIssue("Pending Issue");
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 
 		// Act
@@ -126,7 +126,7 @@ public class ProfilePageTests : IDisposable
 		// Arrange — rejected: Rejected=true
 		var issue = MakeIssue("Rejected Issue") with { Rejected = true };
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 
 		// Act
@@ -143,7 +143,7 @@ public class ProfilePageTests : IDisposable
 		// Arrange — archived: Archived=true, ApprovedForRelease=false, Rejected=false
 		var issue = MakeIssue("Archived Issue") with { Archived = true };
 		_mockIssueClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(MakeResponse(issue)));
 
 		// Act
@@ -180,7 +180,7 @@ public class ProfilePageTests : IDisposable
 
 		var mockClient = Substitute.For<IIssueApiClient>();
 		mockClient
-			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+			.GetAllAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
 			.Returns(Task.FromResult(PaginatedResponse<IssueDto>.Empty));
 		ctx.Services.AddSingleton(mockClient);
 


### PR DESCRIPTION
Closes #121

Implements soft-delete (archive) functionality for Statuses:
- DeleteStatusCommand record with ObjectId Id property  
- DeleteStatusHandler following DeleteCategoryHandler pattern
- DELETE /api/v1/statuses/{id} endpoint (Admin only, returns 204 No Content)
- Handler registration in ServiceCollectionExtensions

Uses existing IStatusRepository.ArchiveAsync method to set Archived=true.

Working as Sam (Backend Developer)

---

**Note:** Pre-existing test failures in Api.Tests.Unit (IssueRepository signature mismatch) and Web tests (@parcel/watcher) are not introduced by this PR.